### PR TITLE
use a fixed interval for metrics

### DIFF
--- a/cmd/ddd/main.go
+++ b/cmd/ddd/main.go
@@ -120,7 +120,7 @@ func main() {
 	api := dogdirect.NewAPI(os.Getenv("DD_API_KEY"), os.Getenv("DD_APP_KEY"), 5*time.Second)
 
 	// create main metrics
-	client = dogdirect.New(hostname, api)
+	client = dogdirect.New(hostname, api, time.Second*15)
 	tasks := dogdirect.MultiTask{
 		dogdirect.NewPeriodic(client, time.Second*15),
 	}

--- a/metric_test.go
+++ b/metric_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBasicTest(t *testing.T) {
 	api := NewAPI("foo", "bar", 0)
-	c := New("hostname", api)
+	c := New("hostname", api, 18*time.Second)
 	c.Incr("counter", []string{"tag1", "role:foo"})
 	c.Incr("anotherc", nil)
 	c.Incr("counter", nil)
@@ -31,5 +31,5 @@ func TestBasicTest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't marhsall: %s", err)
 	}
-	fmt.Printf("raw = %s", string(raw))
+	fmt.Printf("raw = %s\n", string(raw))
 }


### PR DESCRIPTION
Datadog makes calculations based on the interval. if it's derived from actual call time, it can toggle between T and T+1 seconds which throws off calculations.